### PR TITLE
version v0.5.8

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,18 @@
 Changelog
 ***************
 
+.. _0.5.8:
+
+Version 0.5.8
+-------------
+* Added new API call - :py:meth:`Get Snapshot by Contract <odesk.routers.offers.Offers.get_snapshot_by_contract>`.
+* Added new API call - :py:meth:`Update Snapshot memo by Contract <odesk.routers.team.Team_V2.update_snapshot_by_contract>`.
+* Added new API call - :py:meth:`Delete Snapshot by Contract <odesk.routers.team.Team_V2.delete_snapshot_by_contract>`.
+* Fixed broken API call - :py:meth:`Get Work Diary by Contract <odesk.routers.team.Team_V2.get_workdiaries_by_contract>`.
+* Added support of separate parameter ``related_jobcategory2`` in `Send client offer <odesk.routers.offers.Offers.send_client_offer>`
+* Fixed issue with wrong name of ``milestones`` parameter in `Send client offer <odesk.routers.offers.Offers.send_client_offer>`
+* Fixed issue with passing ``milestones`` and ``context`` parameters in `Send client offer <odesk.routers.offers.Offers.send_client_offer>`
+
 .. _0.5.7:
 
 Version 0.5.7

--- a/odesk/__init__.py
+++ b/odesk/__init__.py
@@ -13,7 +13,7 @@ so you can use::
 
 """
 
-VERSION = '0.5.7'
+VERSION = '0.5.8'
 
 
 def get_version():

--- a/odesk/routers/offers.py
+++ b/odesk/routers/offers.py
@@ -70,7 +70,8 @@ class Offers(Namespace):
                           contractor_org=None, context=None,
                           charge_upfront_percent=None, weekly_limit=None,
                           weekly_stipend=None, expires_on=None,
-                          close_on_accept=None, related_jobcategory=None, milestone=None):
+                          close_on_accept=None, related_jobcategory=None,
+                          milestones=None, related_jobcategory2=None):
         """
         Send client offer to the freelancer.
 
@@ -124,6 +125,8 @@ class Offers(Namespace):
                                      `milestones[0][$key]`, ..., `milestones[N][$key]`, where key is one of the following -
                                      `milestone_description` (string), `deposit_amount` (float), `due_date` (string in format mm-dd-yyyy)
 
+          :related_jobcategory2:     Related job category (V2). For example: ``531770282584862733``.
+
         """
         data = {}
 
@@ -151,7 +154,9 @@ class Offers(Namespace):
             data['charge_upfront_percent'] = charge_upfront_percent
 
         if context:
-            data['context'] = context
+            for k, v in context.iteritems():
+                key = 'context[{0}]'.format(k)
+                data[key] = v
 
         if weekly_limit:
             data['weekly_limit'] = weekly_limit
@@ -168,8 +173,14 @@ class Offers(Namespace):
         if related_jobcategory:
             data['related_jobcategory'] = related_jobcategory
 
+        if related_jobcategory2:
+            data['related_jobcategory2'] = related_jobcategory2
+
         if milestones:
-            data['milestones'] = milestones
+            for idx, val in enumerate(milestones):
+                for k, v in val.iteritems():
+                    key = 'milestones[{0}][{1}]'.format(idx, k)
+                    data[key] = v
 
         url = 'clients/offers'
         return self.post(url, data)

--- a/odesk/routers/team.py
+++ b/odesk/routers/team.py
@@ -235,7 +235,7 @@ class Team_V2(Namespace):
                           * 'gmt'
 
         """
-        url = 'workdiarie/contracts/{0}/{1}'.format(contract_id, date)
+        url = 'workdiaries/contracts/{0}/{1}'.format(contract_id, date)
 
         data = {}
 
@@ -252,3 +252,91 @@ class Team_V2(Namespace):
             snapshots = [snapshots]
         
         return result['snapshots']['user'], snapshots
+
+    def get_snapshot_by_contract(self, contract_id, datetime=None):
+        """
+        Retrieve a company's user snapshots by contract ID during given time or 'now'.
+
+        *Parameters:*
+          :contract_id:  The Contract ID
+
+          :datetime:    (optional)(default: 'now')
+                        Timestamp either a datetime object
+                        or a string in ISO 8601 format (in UTC)
+                        ``yyyymmddTHHMMSSZ``
+                        or a string with UNIX timestamp (number of
+                        seconds after epoch)
+
+        """
+        url = 'snapshots/contracts/{0}'.format(contract_id)
+        if datetime:   # date could be a list or a range also
+            url = '{0}/{1}'.format(url, datetime.isoformat())
+
+        result = self.get(url)
+        if 'snapshot' in result:
+            snapshot = result['snapshot']
+        else:
+            snapshot = []
+        if 'error' in result:
+            return result
+        return snapshot
+
+    def update_snapshot_by_contract(self, contract_id, memo, datetime=None):
+        """
+        Update a company's user snapshot memo by contract ID at given time or 'now'.
+
+        *Parameters:*
+          :contract_id:  The Contract ID
+
+          :memo:        The Memo text
+
+          :datetime:    (optoinal)(default 'now')
+                        Timestamp either a datetime object
+                        or a string in ISO 8601 format (in UTC)
+                        ``yyyymmddTHHMMSSZ``
+                        or a string with UNIX timestamp (number of
+                        seconds after epoch)
+
+                        More than one timestamps can be specified either
+                        as a range or as a list of values:
+
+                          - range: use the comma character (,) e.g.
+                            ``20081205T090351Z,20081205T091853Z``
+
+                          - list: use the semicolon character (;) e.g.
+                            ``20081205T090351Z;20081405T090851Z;20081705T091853Z``
+
+        """
+        url = 'snapshots/contracts/{0}'.format(contract_id)
+        if datetime:
+            url = '{0}/{1}'.format(url, datetime.isoformat())
+        return self.put(url, {'memo': memo})
+
+    def delete_snapshot_by_contract(self, contract_id, datetime=None):
+        """
+        Delete a company's user snapshot by contract ID at given time or 'now'.
+
+        *Parameters:*
+          :contract_id:  The Contract ID
+
+          :datetime:    (optional)(default 'now')
+                        Timestamp either a datetime object
+                        or a string in ISO 8601 format (in UTC)
+                        ``yyyymmddTHHMMSSZ``
+                        or a string with UNIX timestamp (number of
+                        seconds after epoch)
+
+                        More than one timestamps can be specified either
+                        as a range or as a list of values:
+
+                          - range: use the comma character (,) e.g.
+                            20081205T090351Z,20081205T091853Z
+
+                          - list: use the semicolon character (;) e.g.
+                            20081205T090351Z;20081405T090851Z;20081705T091853Z
+
+        """
+        url = 'snapshots/contracts/{0}'.format(contract_id)
+        if datetime:
+            url = '{0}/{1}'.format(url, datetime.isoformat())
+        return self.delete(url)

--- a/odesk/tests.py
+++ b/odesk/tests.py
@@ -351,11 +351,22 @@ def test_team():
 
     #test get_teamrooms
     assert te_v2.get_teamrooms() == \
-        [teamrooms_dict['teamrooms']['teamroom']], te.get_teamrooms()
+        [teamrooms_dict['teamrooms']['teamroom']], te_v2.get_teamrooms()
 
     #test get_snapshots
     assert te_v2.get_snapshots(1) == \
-        [teamrooms_dict['teamroom']['snapshot']], te.get_snapshots(1)
+        [teamrooms_dict['teamroom']['snapshot']], te_v2.get_snapshots(1)
+
+    #test get_snapshot by contract
+    assert te_v2.get_snapshot_by_contract(1) == teamrooms_dict['snapshot'], \
+        te_v2.get_snapshot_by_contract(1)
+
+    #test update_snapshot by contract
+    assert te_v2.update_snapshot_by_contract(1, memo='memo') == teamrooms_dict, \
+        te_v2.update_snapshot_by_contract(1, memo='memo')
+
+    #test update_snapshot by contract
+    assert te_v2.delete_snapshot_by_contract(1) == teamrooms_dict, te_v2.delete_snapshot_by_contract(1)
 
     #test get_snapshot
     assert te.get_snapshot(1, 1) == teamrooms_dict['snapshot'], \
@@ -375,6 +386,9 @@ def test_team():
     #test get_workdiaries_by_contract
     eq_(te_v2.get_workdiaries_by_contract(1, 1), (teamrooms_dict['snapshots']['user'],
         [teamrooms_dict['snapshots']['snapshot']]))
+
+    #test get_snapshot_by_contract
+    eq_(te_v2.get_snapshot_by_contract(1), {'status':'private'})
 
 
 teamrooms_dict_none = {'teamrooms': '',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = readme.read()
 readme.close()
 
 
-VERSION = (0, 5, 7, 0, 0)
+VERSION = (0, 5, 8, 0, 0)
 
 
 def get_version():


### PR DESCRIPTION
* Added new Snapshot API - Get Snapshot by Contract
* Added new Snapshot API - Update Snapshot memo by Contract
* Added new Snapshot API - Delete Snapshot by Contract
* Fixed broken Get Work Diary by Contract API call
* Added support of separate parameter ``related_jobcategory2`` in Send client offer API
* Fixed issue with wrong name of ``milestones`` parameter in Send client offer API
* Fixed issue with passing ``milestones`` and ``context`` parameters in Send client offer API